### PR TITLE
Support Go Modules

### DIFF
--- a/example_maxpos_test.go
+++ b/example_maxpos_test.go
@@ -15,7 +15,7 @@
 package bit_test
 
 import (
-	bit "."
+	bit "github.com/andybalholm/go-bit"
 	"fmt"
 )
 

--- a/example_memory_test.go
+++ b/example_memory_test.go
@@ -15,7 +15,7 @@
 package bit_test
 
 import (
-	bit "."
+	bit "github.com/andybalholm/go-bit"
 	"fmt"
 	"math/rand"
 )

--- a/example_test.go
+++ b/example_test.go
@@ -15,7 +15,7 @@
 package bit_test
 
 import (
-	bit "."
+	bit "github.com/andybalholm/go-bit"
 	"fmt"
 )
 

--- a/example_union_test.go
+++ b/example_union_test.go
@@ -15,7 +15,7 @@
 package bit_test
 
 import (
-	bit "."
+	bit "github.com/andybalholm/go-bit"
 	"fmt"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/andybalholm/go-bit
+
+go 1.11


### PR DESCRIPTION
Updating a project referencing [github.com/andybalholm/dhash](https://github.com/andybalholm/dhash) produces the following error:

```
example.com/my/project imports
	github.com/andybalholm/dhash imports
	github.com/andybalholm/go-bit tested by
	github.com/andybalholm/go-bit.test imports
	.: "." is relative, but relative import paths are not supported in module mode
```

This PR should fix the error mentioned above.